### PR TITLE
Return promise on if Optimizely already activated or key not provided

### DIFF
--- a/ng-optimizely.js
+++ b/ng-optimizely.js
@@ -4,11 +4,13 @@ angular.module('ng-optimizely', ['ng'])
     var service = $window.optimizely = $window.optimizely || [];
 
     service.loadProject = function(key, activationEventName) {
-      if (document.getElementById('optimizely-js') || key == void 0) {
-        return;
-      }
-
       var deferred = $q.defer();
+
+      if (document.getElementById('optimizely-js')) {
+        deferred.reject(new Error({message: 'Optimizely already activated'}));
+      } else if (key == void 0) {
+        deferred.reject(new Error({message: 'Key not provided'}));
+      }
 
       script = document.createElement('script');
       script.type = 'text/javascript';


### PR DESCRIPTION
Hi,

I noticed that if you use the ui-router technique in your readme (i.e. to resolve 'loadProject()' inside of $stateProvider) that state change fails if a promise is not returned by loadProject().

Currently, this happens if the initial 'if' statement' in loadProject is triggered and the entire function is returned.  I've modified the code so that, instead, the 'if' statement is divided into separate branches that each return a promise.

Best,
Sean